### PR TITLE
elfutils: Update elfutils licenses

### DIFF
--- a/recipes-debian/elfutils/elfutils_debian.bb
+++ b/recipes-debian/elfutils/elfutils_debian.bb
@@ -1,8 +1,11 @@
 SUMMARY = "Utilities and libraries for handling compiled object files"
 HOMEPAGE = "https://sourceware.org/elfutils"
 SECTION = "base"
-LICENSE = "(GPLv3 & Elfutils-Exception)"
-LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
+LICENSE = "GPLv3+ & GPLv2 & LGPLv3+"
+LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504 \
+                    file://COPYING-GPLV2;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
+                    file://COPYING-LGPLV3;md5=e6a600fd5e1d9cbde2d983680233ad02 \
+                    "
 DEPENDS = "libtool bzip2 zlib virtual/libintl"
 DEPENDS_append_libc-musl = " argp-standalone fts "
 # The Debian patches below are from:
@@ -61,6 +64,18 @@ BBCLASSEXTEND = "native nativesdk"
 
 # Package utilities separately
 PACKAGES =+ "${PN}-binutils libelf libasm libdw"
+
+# shared libraries are licensed GPLv2 or GPLv3+, binaries GPLv3+
+# according to NEWS file:
+# "The license is now GPLv2/LGPLv3+ for the libraries and GPLv3+ for stand-alone
+# programs. There is now also a formal CONTRIBUTING document describing how to
+# submit patches."
+LICENSE_${PN}-binutils = "GPLv3+"
+LICENSE_${PN} = "GPLv3+"
+LICENSE_libelf = "GPLv2 | LGPLv3+"
+LICENSE_libasm = "GPLv2 | LGPLv3+"
+LICENSE_libdw = "GPLv2 | LGPLv3+"
+
 FILES_${PN}-binutils = "\
     ${bindir}/eu-addr2line \
     ${bindir}/eu-ld \


### PR DESCRIPTION
WARNING: elfutils-0.176-r0 do_populate_lic: elfutils: No generic license file exists for: Elfutils-Exception in any provider
Missing licenses: GPLv2 & LGPLv3+

Signed-off-by: Tung Nguyen <tung.nguyenhoang@toshiba-tsdv.com>